### PR TITLE
New feature: los_intersect

### DIFF
--- a/pymap3d/__init__.py
+++ b/pymap3d/__init__.py
@@ -39,7 +39,51 @@ class EarthEllipsoid:
             self.a = 6378137.  # semi-major axis [m]
             self.f = 1 / 298.257222100882711243  # flattening
             self.b = self.a * (1 - self.f)  # semi-minor axis
+            
+def los_intersect(lat0:float, lon0:float, h0:float, az:float, tilt:float,
+                  ell: EarthEllipsoid=None,
+                  deg: bool=True):
+    """
+    Args:
+        lat0, lon0: latitude and longitude of starting point
+        h0: altitude of starting point in meters
+        az: azimuth angle of line-of-sight, clockwise from North
+        tilt: tilt angle of line-of-sight with respect to local vertical (nadir = 0)
+    Returns:
+        lat, lon: latitude and longitude where the line-of-sight intersects with the Earth ellipsoid
+        d: slant range in meters from the starting point to the intersect point
+        Values will be NaN if the line of sight does not intersect.
+    Algorithm based on https://medium.com/@stephenhartzell/satellite-line-of-sight-intersection-with-earth-d786b4a6a9b6 Stephen Hartzell
+    """
 
+    if ell is None:
+        ell = EarthEllipsoid()
+
+    a = ell.a
+    b = ell.a
+    c = ell.b
+
+    if deg:
+        el = np.array(tilt)-90.0
+    else:
+        el = np.array(tilt) - radians(90.0)
+
+    e, n, u = aer2enu(az,el,1,deg=deg)
+    u, v, w = _enu2uvw(e, n, u,lat0,lon0, deg=deg)
+    x,y,z = geodetic2ecef(lat0, lon0, h0, deg=deg)
+
+    value = -a**2*b**2*w*z - a**2*c**2*v*y - b**2*c**2*u*x
+    radical = a**2*b**2*w**2 + a**2*c**2*v**2 - a**2*v**2*z**2 + 2*a**2*v*w*y*z - a**2*w**2*y**2 + b**2*c**2*u**2 - b**2*u**2*z**2 + 2*b**2*u*w*x*z - b**2*w**2*x**2 - c**2*u**2*y**2 + 2*c**2*u*v*x*y - c**2*v**2*x**2
+    magnitude = a**2*b**2*w**2 + a**2*c**2*v**2 + b**2*c**2*u**2
+
+#   Return nan if radical < 0 or d < 0 because LOS vector does not point towards Earth
+    with np.errstate(invalid='ignore'):
+        d = np.where(radical >0, (value - a*b*c*np.sqrt(radical)) / magnitude, np.nan)
+        d = np.where(d<0, np.nan, d)
+
+    lat, lon, h = ecef2geodetic(x + d * u, y + d * v, z + d * w,deg=deg)
+
+    return np.array(lat), np.array(lon), d
 
 # %% to AER (azimuth, elevation, range)
 def ecef2aer(x: float, y: float, z: float,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pymap3d
-version = 1.7.3
+version = 1.7.4
 description = pure Python coordinate conversions, following convention of several popular Matlab routines.
 author = Michael Hirsch, Ph.D.
 url = https://github.com/scivision/pymap3d


### PR DESCRIPTION
This function calculates the latitude and longitude where a line-of-sight, defined by azimuth and tilt (off-nadir) angles from a starting point, intersects with the Earth ellipsoid. It also returns the slant range from the starting point to the intersection point. It has similar functionality to the lookatSpheroid routine in the Matlab mapping toolbox but the algorithm is based on https://gist.github.com/stephenHartzell/00e812ceef6901f30290203945e2cf8b#file-los_intersection-py by @StephenHartzell. 

BTW, I think there may be a small inaccuracy at high latitudes in the enu2uvw function.