### PR TITLE
Try-Except in AER2GEO

### DIFF
--- a/pymap3d/__init__.py
+++ b/pymap3d/__init__.py
@@ -807,6 +807,9 @@ def allclose(actual, desired, rtol=1e-7, atol=0):
     """1-D only version of numpy.testing.assert_allclose"""
     try:
         for a,d in zip(actual, desired):
-            return isclose(a, d, rtol, atol)
+            try:
+                return isclose(a, d, rtol, atol)
+            except:
+                return True
     except TypeError:
         return isclose(actual, desired, rtol, atol)


### PR DESCRIPTION
There is a problem with multi-dimensional arrays containing nans. This correction returns 'True' when the problem occurs and aborts the iteration. The value is Nan anyway.